### PR TITLE
Add support for configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ __pycache__
 /.idea
 /.pytest_cache
 /coverage.xml
+/htmlcov
 /venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
+*.egg
+*.egg-info/
 __pycache__
 /.coverage
 /.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
+sudo: false
 language: python
-python: 3.4
 cache: pip
-
-install: pip install -e . && pip install pytest pytest-cov
-script: py.test -vvv --cov database_sanitizer --cov-report=term-missing
-after_success: curl -s https://codecov.io/bash | bash
+python:
+  - "3.4"
+install:
+  - pip install -r requirements-test.txt
+script:
+  - py.test -vvv --cov database_sanitizer --cov-report=term-missing
+after_success:
+  - curl -s https://codecov.io/bash | bash
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python: 3.4
 cache: pip
 
-install: pip install pytest pytest-cov
+install: pip install -e . && pip install pytest pytest-cov
 script: py.test -vvv --cov database_sanitizer --cov-report=term-missing
 after_success: curl -s https://codecov.io/bash | bash
 

--- a/database_sanitizer/__main__.py
+++ b/database_sanitizer/__main__.py
@@ -9,48 +9,56 @@ from .config import Configuration
 from .dump import run
 
 
-parser = argparse.ArgumentParser(
-    description="Sanitizes contents of databases.",
-)
-parser.add_argument(
-    "--config",
-    "-c",
-    nargs=1,
-    type=str,
-    dest="config",
-    help="Path to the sanitizer configuration file.",
-)
-parser.add_argument(
-    "--output",
-    "-o",
-    nargs=1,
-    type=str,
-    dest="output",
-    help=(
-        "Path to the file where the sanitized database will be written into. "
-        "If omitted, standard output will be used instead."
-    ),
-)
-parser.add_argument(
-    "url",
-    help="Database URL to which to connect into and sanitize contents.",
-)
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
 
-args = parser.parse_args()
-output = sys.stdout
-config = None
-
-if args.config:
-    config = Configuration.from_file(args.config[0])
-if args.output:
-    output = open(args.output[0], "w")
-
-try:
-    run(
-        url=args.url,
-        output=output,
-        config=config,
+    parser = argparse.ArgumentParser(
+        description="Sanitizes contents of databases.",
     )
-finally:
+    parser.add_argument(
+        "--config",
+        "-c",
+        nargs=1,
+        type=str,
+        dest="config",
+        help="Path to the sanitizer configuration file.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        nargs=1,
+        type=str,
+        dest="output",
+        help=(
+            "Path to the file where the sanitized database will be written into. "
+            "If omitted, standard output will be used instead."
+        ),
+    )
+    parser.add_argument(
+        "url",
+        help="Database URL to which to connect into and sanitize contents.",
+    )
+
+    args = parser.parse_args(args=args)
+    output = sys.stdout
+    config = None
+
+    if args.config:
+        config = Configuration.from_file(args.config[0])
     if args.output:
-        output.close()
+        output = open(args.output[0], "w")
+
+    try:
+        run(
+            url=args.url,
+            output=output,
+            config=config,
+        )
+    finally:
+        if args.output:
+            output.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/database_sanitizer/__main__.py
+++ b/database_sanitizer/__main__.py
@@ -5,13 +5,21 @@ from __future__ import unicode_literals
 import argparse
 import sys
 
+from .config import Configuration
 from .dump import run
 
 
 parser = argparse.ArgumentParser(
     description="Sanitizes contents of databases.",
 )
-# TODO: Add --config argument for configuration files.
+parser.add_argument(
+    "--config",
+    "-c",
+    nargs=1,
+    type=str,
+    dest="config",
+    help="Path to the sanitizer configuration file.",
+)
 parser.add_argument(
     "--output",
     "-o",
@@ -30,8 +38,19 @@ parser.add_argument(
 
 args = parser.parse_args()
 output = sys.stdout
+config = None
+
+if args.config:
+    config = Configuration.from_file(args.config[0])
 if args.output:
     output = open(args.output[0], "w")
-run(url=args.url, output=output)
-if args.output:
-    output.close()
+
+try:
+    run(
+        url=args.url,
+        output=output,
+        config=config,
+    )
+finally:
+    if args.output:
+        output.close()

--- a/database_sanitizer/config.py
+++ b/database_sanitizer/config.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import importlib
+import six
+import yaml
+
+__all__ = ("Configuration", "ConfigurationError")
+
+
+class ConfigurationError(ValueError):
+    """
+    Custom exception type used to indicate configuration file errors.
+    """
+
+
+class Configuration(object):
+    """
+    Object representation of database sanitizer configuration, usually read
+    from a YAML file.
+    """
+    def __init__(self):
+        self.sanitizers = {}
+        self.addon_packages = None
+
+    @classmethod
+    def from_file(cls, filename):
+        """
+        Reads configuration from given path to a file in local file system and
+        returns parsed version of it.
+
+        :param filename: Path to the YAML file in local file system where the
+                         configuration will be read from.
+        :type filename: str
+
+        :return: Configuration instance parsed from given configuration file.
+        :rtype: Configuration
+        """
+        instance = cls()
+
+        with open(filename, "rb") as file_stream:
+            config_data = yaml.load(file_stream)
+
+        instance.load(config_data)
+
+        return instance
+
+    def load(self, config_data):
+        """
+        Loads sanitizers according to rulesets defined in given already parsed
+        configuration file.
+
+        :param config_data: Already parsed configuration data, as dictionary.
+        :type config_data: dict[str,any]
+        """
+        if not isinstance(config_data, dict):
+            raise ConfigurationError(
+                "Configuration data is %s instead of dict." % (
+                    type(config_data),
+                )
+            )
+
+        self.load_addon_packages(config_data)
+        self.load_sanitizers(config_data)
+
+    def load_addon_packages(self, config_data):
+        """
+        Loads the module paths from which the configuration will attempt to
+        load sanitizers from. These must be stored as a list of strings under
+        "config.addons" section of the configuration data.
+
+        :param config_data: Already parsed configuration data, as dictionary.
+        :type config_data: dict[str,any]
+        """
+        section_config = config_data.get("config")
+        if not isinstance(section_config, dict):
+            if section_config is None:
+                return
+            raise ConfigurationError(
+                "'config' is %s instead of dict" % (
+                    type(section_config),
+                ),
+            )
+
+        section_addons = section_config.get("addons")
+        if not isinstance(section_addons, list):
+            if section_addons is None:
+                return
+            raise ConfigurationError(
+                "'config.addons' is %s instead of list" % (
+                    type(section_addons),
+                ),
+            )
+
+        for index, module_path in enumerate(section_addons):
+            if not isinstance(module_path, six.text_type):
+                raise ConfigurationError(
+                    "Item %d in 'config.addons' is %s instead of string" % (
+                        index,
+                        type(module_path),
+                    ),
+                )
+
+        self.addon_packages = tuple(section_addons)
+
+    def load_sanitizers(self, config_data):
+        """
+        Loads sanitizers possibly defined in the configuration under dictionary
+        called "strategy", which should contain mapping of database tables with
+        column names mapped into sanitizer function names.
+
+        :param config_data: Already parsed configuration data, as dictionary.
+        :type config_data: dict[str,any]
+        """
+        section_strategy = config_data.get("strategy")
+        if not isinstance(section_strategy, dict):
+            if section_strategy is None:
+                return
+            raise ConfigurationError(
+                "'strategy' is %s instead of dict" % (
+                    type(section_strategy),
+                ),
+            )
+
+        for table_name, column_data in six.iteritems(section_strategy):
+            if not isinstance(column_data, dict):
+                if column_data is None:
+                    continue
+                raise ConfigurationError(
+                    "'strategy.%s' is %s instead of dict" % (
+                        table_name,
+                        type(column_data),
+                    ),
+                )
+
+            for column_name, sanitizer_name in six.iteritems(column_data):
+                if sanitizer_name is None:
+                    continue
+
+                if not isinstance(sanitizer_name, six.text_type):
+                    raise ConfigurationError(
+                        "'strategy.%s.%s' is %s instead of string" % (
+                            table_name,
+                            column_name,
+                            type(sanitizer_name),
+                        ),
+                    )
+
+                sanitizer_callback = self.find_sanitizer(sanitizer_name)
+                sanitizer_key = "%s.%s" % (table_name, column_name)
+                self.sanitizers[sanitizer_key] = sanitizer_callback
+
+    def find_sanitizer(self, name):
+        """
+        Searches for a sanitizer function with given name. The name should
+        contain two parts separated from each other with a dot, the first
+        part being the module name while the second being name of the function
+        contained in the module, when it's being prefixed with "sanitize_".
+
+        The lookup process consists from three attempts, which are:
+
+        1. First package to look the module will be top level package called
+           "sanitizers".
+        2. Module will be looked under the "addon" packages, if they have been
+           defined.
+        3. Finally the sanitation function will be looked from the builtin
+           sanitizers located in "database_sanitizer.sanitizers" package.
+
+        If none of these provide any results, ConfigurationError will be
+        thrown.
+
+        :param name: "Full name" of the sanitation function containing name
+                     of the module as well as name of the function.
+        :type name: str
+
+        :return: First function which can be imported with the given name.
+        :rtype: callable
+        """
+        # Split the sanitizer name into two parts, one containing the Python
+        # module name, while second containing portion of the function name
+        # we are looking for.
+        name_parts = name.split(".")
+        if len(name_parts) < 2:
+            raise ConfigurationError(
+                "Unable to separate module name from function name in '%s'" % (
+                    name,
+                ),
+            )
+
+        module_name_suffix = ".".join(name_parts[:-1])
+        function_name = "sanitize_%s" % (name_parts[-1],)
+
+        # Phase 1: Look for custom sanitizer under a top level package called
+        # "sanitizers".
+        module_name = "sanitizers.%s" % (module_name_suffix,)
+        callback = self.find_sanitizer_from_module(
+            module_name=module_name,
+            function_name=function_name,
+        )
+        if callback:
+            return callback
+
+        # Phase 2: Look for the sanitizer under "addon" packages, if any of
+        # such have been defined.
+        if self.addon_packages:
+            for addon_package_name in self.addon_packages:
+                module_name = "%s.%s" % (
+                    addon_package_name,
+                    module_name_suffix,
+                )
+                callback = self.find_sanitizer_from_module(
+                    module_name=module_name,
+                    function_name=function_name,
+                )
+                if callback:
+                    return callback
+
+        # Phase 3: Look from builtin sanitizers.
+        module_name = "database_sanitizer.sanitizers.%s" % (module_name_suffix,)
+        callback = self.find_sanitizer_from_module(
+            module_name=module_name,
+            function_name=function_name,
+        )
+        if callback:
+            return callback
+
+        # Give up.
+        raise ConfigurationError("Unable to find sanitizer called '%s'" % (
+            name,
+        ))
+
+    @staticmethod
+    def find_sanitizer_from_module(module_name, function_name):
+        """
+        Attempts to find sanitizer function from given module. If the module
+        cannot be imported, or function with given name does not exist in it,
+        nothing will be returned by this method. Otherwise the found sanitizer
+        function will be returned.
+
+        :param module_name: Name of the module to import the function from.
+        :type module_name: str
+
+        :param function_name: Name of the function to look for inside the
+                              module.
+        :type function_name: str
+
+        :return: Sanitizer function found from the module, if it can be
+                 imported and it indeed contains function with the given name.
+                 Otherwise None will be returned instead.
+        :rtype: callback|None
+        """
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            return None
+
+        # Look for the function inside the module. At this point it could be
+        # pretty much anything.
+        callback = getattr(module, function_name, None)
+
+        # Function does not exist in this module? Give up.
+        if callback is None:
+            return None
+
+        # It's actually callable function? Return it.
+        if callable(callback):
+            return callback
+
+        # Sanitizer seems to be something else than a function. Throw an
+        # exception to report such problem.
+        raise ConfigurationError("'%s' in '%s' is %s instead of function" % (
+            function_name,
+            module_name,
+            type(callback),
+        ))
+
+    def sanitize(self, table_name, column_name, value):
+        """
+        Sanitizes given value extracted from the database according to the
+        sanitation configuration.
+
+        TODO: Add support for dates, booleans and other types found in SQL than
+        string.
+
+        :param table_name: Name of the database table from which the value is
+                           from.
+        :type table_name: str
+
+        :param column_name: Name of the database column from which the value is
+                            from.
+        :type column_name: str
+
+        :param value: Value from the database, either in text form or None if
+                      the value is null.
+        :type value: str|None
+
+        :return: Sanitized version of the given value.
+        :rtype: str|None
+        """
+        sanitizer_key = "%s.%s" % (table_name, column_name)
+        sanitizer_callback = self.sanitizers.get(sanitizer_key)
+        return sanitizer_callback(value) if sanitizer_callback else value

--- a/database_sanitizer/dump/__init__.py
+++ b/database_sanitizer/dump/__init__.py
@@ -16,7 +16,7 @@ urlparse.uses_netloc.append("postgres")
 urlparse.uses_netloc.append("postgresql")
 
 
-def run(url, output):
+def run(url, output, config):
     """
     Extracts database dump from given database URL and outputs sanitized
     copy of it into given stream.
@@ -27,11 +27,15 @@ def run(url, output):
     :param output: Stream where sanitized copy of the database dump will be
                    written into.
     :type output: file
+
+    :param config: Optional sanitizer configuration to be used for sanitation
+                   of the values stored in the database.
+    :type config: database_sanitizer.config.Configuration|None
     """
     parsed_url = urlparse.urlparse(url)
     db_module_path = SUPPORTED_DATABASE_MODULES.get(parsed_url.scheme)
     if not db_module_path:
         raise ValueError("Unsupported database scheme: '%s'" % (parsed_url.scheme,))
     db_module = importlib.import_module(db_module_path)
-    for line in db_module.sanitize(url=parsed_url):
+    for line in db_module.sanitize(url=parsed_url, config=config):
         output.write(line + "\n")

--- a/database_sanitizer/dump/postgres.py
+++ b/database_sanitizer/dump/postgres.py
@@ -14,7 +14,7 @@ COPY_LINE_PATTERN = re.compile(
 )
 
 
-def sanitize(url):
+def sanitize(url, config):
     """
     Obtains dump of an Postgres database by executing `pg_dump` command and
     sanitizes it's output.
@@ -22,6 +22,10 @@ def sanitize(url):
     :param url: URL to the database which is going to be sanitized, parsed by
                 Python's URL parser.
     :type url: six.moves.urllib.parse.ParseResult
+
+    :param config: Optional sanitizer configuration to be used for sanitation
+                   of the values stored in the database.
+    :type config: database_sanitizer.config.Configuration|None
     """
     if url.scheme not in ("postgres", "postgresql"):
         raise ValueError("Unsupported database type: '%s'" % (url.scheme,))
@@ -66,7 +70,12 @@ def sanitize(url):
                 raise ValueError("Mismatch between column names and values.")
 
             for index, value in enumerate(unsanitized_values):
-                # TODO: Perform the actual sanitation here.
+                if config:
+                    value = config.sanitize(
+                        table_name=current_table,
+                        column_name=current_table_columns[index],
+                        value=value,
+                    )
                 sanitized_values.append(value)
 
             # Convert sanitized values back into column values.

--- a/database_sanitizer/tests/test_config.py
+++ b/database_sanitizer/tests/test_config.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from ..config import Configuration, ConfigurationError
+
+
+def test_load_addon_packages():
+    config = Configuration()
+
+    config.load_addon_packages({})
+    assert config.addon_packages is None
+
+    with pytest.raises(ConfigurationError):
+        config.load_addon_packages({"config": "test"})
+
+    config.load_addon_packages({"config": {}})
+    assert config.addon_packages is None
+
+    with pytest.raises(ConfigurationError):
+        config.load_addon_packages({"config": {"addons": "test"}})
+
+    with pytest.raises(ConfigurationError):
+        config.load_addon_packages({"config": {"addons": [True]}})
+
+    config.load_addon_packages({"config": {
+        "addons": [
+            "test1",
+            "test2",
+            "test3",
+        ],
+    }})
+    assert config.addon_packages == ("test1", "test2", "test3")
+
+
+def test_sanitize():
+    config = Configuration()
+    config.sanitizers["a.a"] = lambda value: value.upper()
+    config.sanitizers["a.b"] = lambda value: value[::-1]
+
+    assert config.sanitize("a", "a", "test") == "TEST"
+    assert config.sanitize("a", "b", "test") == "tset"
+    assert config.sanitize("a", "c", "test") == "test"

--- a/database_sanitizer/tests/test_config.py
+++ b/database_sanitizer/tests/test_config.py
@@ -4,7 +4,17 @@ from __future__ import unicode_literals
 
 import pytest
 
+from collections import namedtuple
+from unittest import mock
+
 from ..config import Configuration, ConfigurationError
+
+
+def test_load_config_data_must_be_dict():
+    config = Configuration()
+    config.load({})
+    with pytest.raises(ConfigurationError):
+        config.load(config_data="test")
 
 
 def test_load_addon_packages():
@@ -33,6 +43,125 @@ def test_load_addon_packages():
         ],
     }})
     assert config.addon_packages == ("test1", "test2", "test3")
+
+
+def test_load_sanitizers():
+    config = Configuration()
+
+    with pytest.raises(ConfigurationError):
+        config.load_sanitizers({"strategy": "test"})
+
+    with pytest.raises(ConfigurationError):
+        config.load_sanitizers({"strategy": {"test": "test"}})
+
+    def mock_find_sanitizer(*args):
+        return lambda value: value
+
+    with mock.patch("database_sanitizer.config.Configuration.find_sanitizer",
+                    side_effect=mock_find_sanitizer):
+        with pytest.raises(ConfigurationError):
+            config.load_sanitizers({"strategy": {"table1": {"column1": True}}})
+
+        config.load_sanitizers({"strategy": {
+            "table1": {
+                "column1": None,
+                "column2": "test.test",
+            },
+            "table2": {
+                "column1": "test.test",
+            },
+            "table3": None,
+        }})
+
+    assert "table1.column1" not in config.sanitizers
+    assert "table1.column2" in config.sanitizers
+    assert "table2.column1" in config.sanitizers
+
+
+def test_find_sanitizer():
+    config = Configuration()
+
+    with pytest.raises(ConfigurationError):
+        config.find_sanitizer("test")
+
+    def mock_find_sanitizer_from_module1(module_name, function_name):
+        assert module_name == "sanitizers.test"
+        assert function_name == "sanitize_test"
+        return lambda value: value
+
+    with mock.patch("database_sanitizer.config.Configuration.find_sanitizer_from_module",
+                    side_effect=mock_find_sanitizer_from_module1):
+        assert config.find_sanitizer("test.test") is not None
+
+    def mock_find_sanitizer_from_module2(module_name, function_name):
+        assert module_name in ("sanitizers.test", "addon.test")
+        assert function_name == "sanitize_test"
+        if module_name.startswith("addon."):
+            return lambda value: value
+        else:
+            return None
+
+    with mock.patch("database_sanitizer.config.Configuration.find_sanitizer_from_module",
+                    side_effect=mock_find_sanitizer_from_module2):
+        config.addon_packages = ("addon",)
+        assert config.find_sanitizer("test.test") is not None
+
+    def mock_find_sanitizer_from_module3(module_name, function_name):
+        assert module_name in (
+            "sanitizers.test",
+            "addon.test",
+            "database_sanitizer.sanitizers.test",
+        )
+        assert function_name == "sanitize_test"
+        if module_name.startswith("database_sanitizer."):
+            return lambda value: value
+        else:
+            return None
+
+    with mock.patch("database_sanitizer.config.Configuration.find_sanitizer_from_module",
+                    side_effect=mock_find_sanitizer_from_module3):
+        assert config.find_sanitizer("test.test") is not None
+
+    def mock_find_sanitizer_from_module4(module_name, function_name):
+        return None
+
+    with mock.patch("database_sanitizer.config.Configuration.find_sanitizer_from_module",
+                    side_effect=mock_find_sanitizer_from_module4):
+        with pytest.raises(ConfigurationError):
+            config.find_sanitizer("test.test")
+
+
+def test_find_sanitizer_from_module():
+    def mock_import1(module_name):
+        assert module_name == "test"
+        raise ImportError("Should be catched")
+
+    with mock.patch("importlib.import_module", side_effect=mock_import1):
+        assert Configuration.find_sanitizer_from_module("test", "test") is None
+
+    mock_module_type = namedtuple("mock_module", ("test",))
+
+    def mock_import2(module_name):
+        assert module_name == "test"
+        return mock_module_type(test=None)
+
+    with mock.patch("importlib.import_module", side_effect=mock_import2):
+        assert Configuration.find_sanitizer_from_module("test", "test") is None
+
+    def mock_import3(module_name):
+        assert module_name == "test"
+        return mock_module_type(test=lambda value: value)
+
+    with mock.patch("importlib.import_module", side_effect=mock_import3):
+        assert Configuration.find_sanitizer_from_module("test", "test") is not None
+
+    def mock_import4(module_name):
+        assert module_name == "test"
+        return mock_module_type(test="test")
+
+    with mock.patch("importlib.import_module", side_effect=mock_import4):
+        with pytest.raises(ConfigurationError):
+            Configuration.find_sanitizer_from_module("test", "test")
 
 
 def test_sanitize():

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+-e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
-    database-sanitizer = database_sanitizer.__main__
+    database-sanitizer = database_sanitizer.__main__:main
 
 [bdist_wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = database-sanitizer
+version = 0.1.0
+description = Sanitizes contents of a database.
+url = https://github.com/andersinno/python-database-sanitizer
+
+[options]
+include_package_data = true
+install_requires =
+    PyYAML>=3.12
+    six>=1.11.0
+
+[options.entry_points]
+console_scripts =
+    database-sanitizer = database_sanitizer.__main__
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "database_sanitizer.utils",
     ],
     install_requires=[
+        "PyYAML>=3.12",
         "six>=1.11.0",
     ],
     platforms=["OS Independent"],

--- a/setup.py
+++ b/setup.py
@@ -2,23 +2,8 @@
 
 from __future__ import unicode_literals
 
-from setuptools import setup
+import setuptools
 
 
-setup(
-    name="database-sanitizer",
-    version="0.1.0",
-    descriptions="Sanitizes contents of a database.",
-    url="https://github.com/andersinno/python-database-sanitizer",
-    include_package_data=True,
-    packages=[
-        "database_sanitizer",
-        "database_sanitizer.dump",
-        "database_sanitizer.utils",
-    ],
-    install_requires=[
-        "PyYAML>=3.12",
-        "six>=1.11.0",
-    ],
-    platforms=["OS Independent"],
-)
+if __name__ == "__main__":
+    setuptools.setup(setup_requires=["setuptools>=34.0"])


### PR DESCRIPTION
Add support for configuration files, as described [in this stub specification of sorts](https://github.com/andersinno/django-sanitized-dump/blob/c4ba725/README.md#example-config).