### PR TITLE
Fix configuration example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ config:
   addons:
     - some.other.package
     - yet.another.package
-  strategy:
-    user:
-      first_name: name.first_name
-      last_name: name.last_name
-      secret_key: string.empty
+strategy:
+  user:
+    first_name: name.first_name
+    last_name: name.last_name
+    secret_key: string.empty
 ```
 
 In the example configuration above, there are first listed two "addon


### PR DESCRIPTION
Example of sanitation configuration in `README.md` is currently
incorrect, as it accidentally places section `strategy` under section
`config`, when it should be top level section.