### PR TITLE
Implement couple encoding/decoding related optimizations

### DIFF
--- a/database_sanitizer/tests/test_utils_postgres.py
+++ b/database_sanitizer/tests/test_utils_postgres.py
@@ -6,6 +6,7 @@ import pytest
 
 from ..utils.postgres import (
     decode_copy_value,
+    DECODE_MAP,
     encode_copy_value,
     POSTGRES_COPY_NULL_VALUE,
 )
@@ -60,3 +61,26 @@ def test_invalid_escape_sequence():
         decode_copy_value("\\")
     with pytest.raises(ValueError):
         decode_copy_value("\\X")
+
+
+def test_decode_map_contents():
+    assert DECODE_MAP['\\b'] == '\b'
+    assert DECODE_MAP['\\n'] == '\n'
+    assert DECODE_MAP['\\t'] == '\t'
+    assert DECODE_MAP['\\\\'] == '\\'
+    assert DECODE_MAP['\\0'] == '\0'
+    assert DECODE_MAP['\\74'] == '\74'
+    assert DECODE_MAP['\\x0'] == '\0'
+    assert DECODE_MAP['\\xa'] == '\x0a'
+    assert DECODE_MAP['\\xA'] == '\x0a'
+    assert DECODE_MAP['\\x00'] == '\0'
+    assert DECODE_MAP['\\xa3'] == '\xa3'
+    assert DECODE_MAP['\\xA3'] == '\xa3'
+    assert DECODE_MAP['\\xAb'] == '\xab'
+    assert DECODE_MAP['\\xaB'] == '\xab'
+    assert DECODE_MAP['\\xff'] == '\xff'
+
+    assert '\\' not in DECODE_MAP,  "Unterminated escape is not mapped"
+    assert '\\z' not in DECODE_MAP,  "Invalid escape sequences are not mapped"
+
+    assert len(DECODE_MAP) == 1097


### PR DESCRIPTION
In `sanitize` function: Skip the decoding and encoding of columns which
don't have a sanitizer configured.

And optimize PostgreSQL escape decoding and encoding.  These
optimizations make the value encoding/decoding 175% faster on my
machine.  Total runtime for sanitizing 2.21GiB of SQL data dropped from
846s to 308s, when using a `lambda x: x` sanitizer for every column (to
force decoding and encoding of all values).

See the commit messages for details.