### PR TITLE
Add support for MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# Database sanitation tool [![travis][travis-image]][travis-url] [![codecov][codecov-image]][codecov-url]
+# Database sanitation tool
 
+[![pypi][pypi-image]][pypi-url]
+[![travis][travis-image]][travis-url]
+[![codecov][codecov-image]][codecov-url]
+
+[pypi-image]: https://badge.fury.io/py/database-sanitizer.svg
+[pypi-url]: https://pypi.org/project/database-sanitizer/
 [travis-image]: https://travis-ci.org/andersinno/python-database-sanitizer.svg?branch=master
 [travis-url]: https://travis-ci.org/andersinno/python-database-sanitizer
 [codecov-image]: https://codecov.io/gh/andersinno/python-database-sanitizer/branch/master/graph/badge.svg
@@ -7,12 +13,29 @@
 
 `database-sanitizer` is a tool which retrieves an database dump from
 relational database and performs sanitation on the retrieved data
-according to rules defined in a configuration file. Currently only
-supported database backend is [PostgreSQL], but support for [MySQL] is
-planned to be added in the future.
+according to rules defined in a configuration file. Currently the
+sanitation tool supports both [PostgreSQL] and [MySQL] databases.
 
 [PostgreSQL]: https://postgres.org
 [MySQL]: https://mysql.com
+
+## Installation
+
+`database-sanitizer` can be installed from [PyPI] with [pip] like this:
+
+```bash
+$ pip install database-sanitizer
+```
+
+If you are using MySQL, you need to install the package like this
+instead, so that additional requirements are included:
+
+```bash
+$ pip install database-sanitizer[MySQL]
+```
+
+[PyPI]: https://pypi.org
+[pip]: https://pip.pypa.io/en/stable/
 
 ## Usage
 

--- a/database_sanitizer/dump/__init__.py
+++ b/database_sanitizer/dump/__init__.py
@@ -8,12 +8,14 @@ from six.moves.urllib import parse as urlparse
 
 
 SUPPORTED_DATABASE_MODULES = {
+    "mysql": "database_sanitizer.dump.mysql",
     "postgres": "database_sanitizer.dump.postgres",
     "postgresql": "database_sanitizer.dump.postgres",
 }
 
 
 # Register supported database schemes.
+urlparse.uses_netloc.append("mysql")
 urlparse.uses_netloc.append("postgres")
 urlparse.uses_netloc.append("postgresql")
 

--- a/database_sanitizer/dump/mysql.py
+++ b/database_sanitizer/dump/mysql.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import io
+import re
+import subprocess
+
+from ..utils.mysql import (
+    decode_mysql_literal,
+    encode_mysql_literal,
+    get_mysqldump_args_and_env_from_url,
+)
+
+
+#: Regular expression which matches `INSERT INTO` statements produced by the
+#: `mysqldump` utility, even when extended inserts have been enabled.
+INSERT_INTO_PATTERN = re.compile(
+    r"^INSERT INTO `(?P<table>[^`]*)`"
+    r" \((?P<columns>.*)\)"
+    r" VALUES (?P<values>.*);$"
+)
+
+
+#: Regular expression which matches various kinds of MySQL literals.
+VALUE_PATTERN = re.compile(
+    r"""
+    # Group 1:
+    (
+        '(?:[^']|''|\\')*(?<![\\])'     # String literal
+        |                               # or...
+        [^',()]+                        # NULL, TRUE, etc.
+    )
+    # Group 2:
+    (
+        [,)]                            # Comma or closing parenthesis.
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def sanitize(url, config):
+    """
+    Obtains dump of MySQL database by executing `mysqldump` command and
+    sanitizes it output.
+
+    :param url: URL to the database which is going to be sanitized, parsed by
+                Python's URL parser.
+    :type url: urllib.urlparse.ParseResult
+
+    :param config: Optional sanitizer configuration to be used for sanitation
+                   of the values stored in the database.
+    :type config: database_sanitizer.config.Configuration|None
+    """
+    if url.scheme != "mysql":
+        raise ValueError("Unsupported database type: '%s'" % (url.scheme,))
+
+    args, env = get_mysqldump_args_and_env_from_url(url=url)
+
+    process = subprocess.Popen(
+        args=["mysqldump"] + args,
+        env=env,
+        stdout=subprocess.PIPE,
+    )
+
+    return sanitize_from_stream(stream=process.stdout, config=config)
+
+
+def sanitize_from_stream(stream, config):
+    """
+    Reads dump of MySQL database from given stream and sanitizes it.
+
+    :param stream: Stream where the database dump is expected to be available
+                   from, such as stdout of `mysqldump` process.
+    :type stream: file
+
+    :param config: Optional sanitizer configuration to be used for sanitation
+                   of the values stored in the database.
+    :type config: database_sanitizer.config.Configuration|None
+    """
+    for line in io.TextIOWrapper(stream, encoding="utf-8"):
+        # Eat the trailing new line.
+        line = line.rstrip("\n")
+
+        # If there is no configuration it means that there are no sanitizers
+        # available.
+        if not config:
+            yield line
+            continue
+
+        # Does the line contain `INSERT INTO` statement? If not, use the line
+        # as-is and continue into next one.
+        insert_into_match = INSERT_INTO_PATTERN.match(line)
+        if not insert_into_match:
+            yield line
+            continue
+
+        table_name = insert_into_match.group("table")
+        column_names = parse_column_names(insert_into_match.group("columns"))
+
+        # Collect sanitizers possibly used for this table and place them into
+        # a dictionary from which we can look them up by index later.
+        sanitizers = {}
+        for index, column_name in enumerate(column_names):
+            sanitizer = config.get_sanitizer_for(
+                table_name=table_name,
+                column_name=column_name,
+            )
+            if sanitizer:
+                sanitizers[index] = sanitizer
+
+        # If this table has no sanitizers available, use the line as-is and
+        # continue into next line.
+        if len(sanitizers) == 0:
+            yield line
+            continue
+
+        # Constructs list of tuples containing sanitized column names.
+        sanitized_value_tuples = []
+        for values in parse_values(insert_into_match.group("values")):
+            if len(column_names) != len(values):
+                raise ValueError("Mismatch between column names and values")
+            sanitized_values = []
+            for index, value in enumerate(values):
+                sanitizer_callback = sanitizers.get(index)
+                if sanitizer_callback:
+                    value = sanitizer_callback(value)
+                sanitized_values.append(encode_mysql_literal(value))
+            sanitized_value_tuples.append(sanitized_values)
+
+        # Finally create new `INSERT INTO` statement from the sanitized values.
+        yield "INSERT INTO `%s` (%s) VALUES %s;" % (
+            table_name,
+            ", ".join("`" + column_name + "`" for column_name in column_names),
+            ",".join(
+                "(" + ",".join(value_tuple) + ")"
+                for value_tuple in sanitized_value_tuples
+            ),
+        )
+
+
+def parse_column_names(text):
+    """
+    Extracts column names from a string containing quoted and comma separated
+    column names of a table.
+
+    :param text: Line extracted from MySQL's `INSERT INTO` statement containing
+                 quoted and comma separated column names.
+    :type text: str
+
+    :return: Tuple containing just the column names.
+    :rtype: tuple[str]
+    """
+    return tuple(
+        re.sub(r"^`(.*)`$", r"\1", column_data.strip())
+        for column_data in text.split(",")
+    )
+
+
+def parse_values(text):
+    """
+    Parses values from a string containing values from extended format `INSERT
+    INTO` statement. Values will be yielded from the function as tuples, with
+    one tuple per row in the table.
+
+    :param text: Text extracted from MySQL's `INSERT INTO` statement containing
+                 quoted and comma separated column values.
+    :type text: str
+    """
+    assert text.startswith("(")
+    pos = 1
+    values = []
+    text_len = len(text)
+    while pos < text_len:
+        match = VALUE_PATTERN.match(text, pos)
+        if not match:
+            break
+        value = match.group(1)
+        values.append(decode_mysql_literal(value.strip()))
+        pos += len(value) + 1
+        if match.group(2) == ")":
+            # Skip comma and open parenthesis ",("
+            pos += 2
+            yield tuple(values)
+            values = []

--- a/database_sanitizer/tests/test_dump_mysql.py
+++ b/database_sanitizer/tests/test_dump_mysql.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import io
+import pytest
+
+from six.moves.urllib import parse as urlparse
+
+from ..config import Configuration
+from ..dump.mysql import (
+    parse_column_names,
+    parse_values,
+    sanitize,
+    sanitize_from_stream,
+)
+
+
+MOCK_MYSQLDUMP_OUTPUT = b"""
+--- Fake MySQL database dump
+
+DROP TABLE IF EXISTS `test`;
+
+INSERT INTO `test` (`id`, `created_at`, `notes`) VALUES \
+(1,'2018-01-01','Test data 1'),\
+(2,'2018-01-02','Test data 2'),\
+(3,'2018-01-03','Test data 3');
+
+--- Final line after `INSERT INTO` statement.
+"""
+
+
+INVALID_MOCK_MYSQLDUMP_OUTPUT = b"""
+--- Fake MySQL database dump
+
+DROP TABLE IF EXISTS `test`;
+
+INSERT INTO `test` (`id`, `created_at`, `notes`) VALUES (1),(2),(3);
+
+--- Final line after `INSERT INTO` statement.
+"""
+
+
+def test_sanitize_wrong_scheme():
+    url = urlparse.urlparse("http://localhost/test")
+    with pytest.raises(ValueError):
+        list(sanitize(url, None))
+
+
+def test_sanitize_from_stream():
+    stream = io.BytesIO(MOCK_MYSQLDUMP_OUTPUT)
+    config = Configuration()
+    config.sanitizers["test.notes"] = lambda value: "Sanitized"
+    dump_output_lines = list(sanitize_from_stream(stream, config))
+
+    assert "--- Fake MySQL database dump" in dump_output_lines
+    assert "--- Final line after `INSERT INTO` statement." in dump_output_lines
+    assert """INSERT INTO `test` (`id`, `created_at`, `notes`) VALUES \
+(1,'2018-01-01','Sanitized'),\
+(2,'2018-01-02','Sanitized'),\
+(3,'2018-01-03','Sanitized');\
+""" in dump_output_lines
+
+
+def test_sanitizer_invalid_input():
+    stream = io.BytesIO(INVALID_MOCK_MYSQLDUMP_OUTPUT)
+    config = Configuration()
+    config.sanitizers["test.notes"] = lambda value: "Sanitized"
+
+    with pytest.raises(ValueError):
+        list(sanitize_from_stream(stream, config))
+
+
+@pytest.mark.parametrize(
+    "text,expected_column_names",
+    (
+        ("`test`", ("test",)),
+        ("`test`, `test`", ("test", "test")),
+        ("`test`,`test`", ("test", "test")),
+    ),
+)
+def test_parse_column_names(text, expected_column_names):
+    assert parse_column_names(text) == expected_column_names
+
+
+@pytest.mark.parametrize(
+    "text,expected_values",
+    (
+        ("('test'),('test')", (("test",), ("test",))),
+        ("(1,2),(3,4),", ((1, 2), (3, 4))),
+        ("(TRUE),(FALSE),(NULL)", ((True,), (False,), (None,))),
+    ),
+)
+def test_parse_values(text, expected_values):
+    assert tuple(parse_values(text)) == expected_values

--- a/database_sanitizer/tests/test_utils_mysql.py
+++ b/database_sanitizer/tests/test_utils_mysql.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from six.moves.urllib import parse as urlparse
+
+from ..utils.mysql import (
+    decode_mysql_literal,
+    decode_mysql_string_literal,
+    get_mysqldump_args_and_env_from_url,
+    unescape_single_character,
+)
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "mysql://test:test@localhost/test",
+        "mysql://localhost:1234/test",
+        "mysql://localhost",
+    ),
+)
+def test_get_mysqldump_args_and_env_from_url(url):
+    parsed_url = urlparse.urlparse(url)
+
+    if not parsed_url.path:
+        with pytest.raises(ValueError):
+            get_mysqldump_args_and_env_from_url(url=parsed_url)
+        return
+
+    args, env = get_mysqldump_args_and_env_from_url(url=parsed_url)
+
+    assert isinstance(args, list)
+    assert isinstance(env, dict)
+
+    assert len(args) > 0
+    assert "--complete-insert" in args
+    assert "--extended-insert" in args
+    assert "--net_buffer_length=10240" in args
+    assert args[-1] == parsed_url.path[1:]
+
+    if parsed_url.username:
+        index = args.index("-u")
+        assert args[index + 1] == parsed_url.username
+
+    if parsed_url.password:
+        assert env["MYSQL_PWD"] == parsed_url.password
+
+
+@pytest.mark.parametrize(
+    "text,expected_value",
+    (
+        ("NULL", None),
+        ("TRUE", True),
+        ("FALSE", False),
+        ("12", 12),
+        ("12.5", 12.5),
+        ("'test'", "test"),
+    ),
+)
+def test_decode_mysql_literal(text, expected_value):
+    assert decode_mysql_literal(text) == expected_value
+
+
+def test_decode_mysql_literal_invalid_input():
+    with pytest.raises(ValueError):
+        decode_mysql_literal("ERROR")
+
+
+@pytest.mark.parametrize(
+    "text,expected_output",
+    (
+        ("'test'", "test"),
+        ("'test\\ntest'", "test\ntest"),
+        ("'\\0'", "\000"),
+        ("'foo", None),
+        ("foo'", None),
+        ("foo", None),
+    ),
+)
+def test_decode_mysql_string_literal(text, expected_output):
+    if expected_output is None:
+        with pytest.raises(AssertionError):
+            decode_mysql_string_literal(text)
+    else:
+        assert decode_mysql_string_literal(text) == expected_output
+
+
+@pytest.mark.parametrize(
+    "text,expected_output",
+    (
+        ("\\\\", "\\"),
+        ("\\n", "\n"),
+        ("\\r", "\r"),
+        ("\\0", "\000"),
+        ("\\Z", "\032"),
+        ("\\'", "'"),
+        ('\\"', '"'),
+    ),
+)
+def test_unescape_single_character(text, expected_output):
+    class MockRegexpMatch(object):
+
+        def __init__(self, text):
+            self.text = text
+
+        def group(self, index):
+            assert index == 0
+            return self.text
+
+    assert unescape_single_character(MockRegexpMatch(text)) == expected_output

--- a/database_sanitizer/utils/mysql.py
+++ b/database_sanitizer/utils/mysql.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import re
+import six
+
+try:
+    import pymysql
+except ImportError:
+    raise RuntimeError("You need to install PyMySQL for MySQL support")
+
+
+def get_mysqldump_args_and_env_from_url(url):
+    """
+    Constructs list of command line arguments and dictionary of environment
+    variables that can be given to `mysqldump` executable to obtain database
+    dump of the database described in given URL.
+
+    :param url: Parsed database URL.
+    :type url: urllib.urlparse.ParseResult
+
+    :return: List of command line arguments as well as dictionary of
+             environment variables that can be used to launch the MySQL dump
+             process to obtain dump of the database.
+    :rtype: tuple[list[str],dict[str,str]]
+    """
+    args = [
+        # Without this, `INSERT INTO` statements will exclude column names from
+        # the output, which are required for sanitation.
+        "--complete-insert",
+
+        # This enables use for "exteded inserts" where multiple rows of a table
+        # are included in a single `INSERT INTO` statement (contents of the
+        # entire table even, if it's within limits). We use it to increase the
+        # performance of the sanitation and to decrease the dump size.
+        "--extended-insert",
+
+        # This makes the `mysqldump` to attempt to limit size of a single line
+        # into 10 megabytes. We use it to reduce memory consumption.
+        "--net_buffer_length=10240",
+
+        # Hostname of the database to connect into, should be always present in
+        # the parsed database URL.
+        "-h",
+        url.hostname,
+    ]
+    env = {}
+
+    if url.port is not None:
+        args.extend(("-P", six.text_type(url.port)))
+
+    if url.username:
+        args.extend(("-u", url.username))
+
+    if url.password:
+        env["MYSQL_PWD"] = url.password
+
+    if len(url.path) < 2 or not url.path.startswith("/"):
+        raise ValueError("Name of the database is missing from the URL")
+
+    args.append(url.path[1:])
+
+    return args, env
+
+
+MYSQL_NULL_PATTERN = re.compile(r"^NULL$", re.IGNORECASE)
+MYSQL_BOOLEAN_PATTERN = re.compile(r"^(TRUE|FALSE)$", re.IGNORECASE)
+MYSQL_FLOAT_PATTERN = re.compile(r"^[+-]?\d*\.\d+([eE][+-]?\d+)?$")
+MYSQL_INT_PATTERN = re.compile(r"^\d+$")
+MYSQL_STRING_PATTERN = re.compile(r"'(?:[^']|''|\\')*(?<![\\])'")
+
+
+def decode_mysql_literal(text):
+    """
+    Attempts to decode given MySQL literal into Python value.
+
+    :param text: Value to be decoded, as MySQL literal.
+    :type text: str
+
+    :return: Python version of the given MySQL literal.
+    :rtype: any
+    """
+    if MYSQL_NULL_PATTERN.match(text):
+        return None
+
+    if MYSQL_BOOLEAN_PATTERN.match(text):
+        return text.lower() == "true"
+
+    if MYSQL_FLOAT_PATTERN.match(text):
+        return float(text)
+
+    if MYSQL_INT_PATTERN.match(text):
+        return int(text)
+
+    if MYSQL_STRING_PATTERN.match(text):
+        return decode_mysql_string_literal(text)
+
+    raise ValueError("Unable to decode given value: %r" % (text,))
+
+
+MYSQL_STRING_ESCAPE_SEQUENCE_PATTERN = re.compile(r"\\(.)")
+MYSQL_STRING_ESCAPE_SEQUENCE_MAPPING = {
+    "\\0": "\000",
+    "\\b": "\b",
+    "\\n": "\n",
+    "\\r": "\r",
+    "\\t": "\t",
+    "\\Z": "\032",
+}
+
+
+def decode_mysql_string_literal(text):
+    """
+    Removes quotes and decodes escape sequences from given MySQL string literal
+    returning the result.
+
+    :param text: MySQL string literal, with the quotes still included.
+    :type text: str
+
+    :return: Given string literal with quotes removed and escape sequences
+             decoded.
+    :rtype: str
+    """
+    assert text.startswith("'")
+    assert text.endswith("'")
+
+    # Ditch quotes from the string literal.
+    text = text[1:-1]
+
+    return MYSQL_STRING_ESCAPE_SEQUENCE_PATTERN.sub(
+        unescape_single_character,
+        text,
+    )
+
+
+def unescape_single_character(match):
+    """
+    Unescape a single escape sequence found from a MySQL string literal,
+    according to the rules defined at:
+    https://dev.mysql.com/doc/refman/5.6/en/string-literals.html#character-escape-sequences
+
+    :param match: Regular expression match object.
+
+    :return: Unescaped version of given escape sequence.
+    :rtype: str
+    """
+    value = match.group(0)
+    assert value.startswith("\\")
+    return MYSQL_STRING_ESCAPE_SEQUENCE_MAPPING.get(value) or value[1:]
+
+
+def encode_mysql_literal(value):
+    """
+    Converts given Python value into MySQL literal, suitable to be used inside
+    `INSERT INTO` statement.
+
+    :param value: Value to convert into MySQL literal.
+    :type value: any
+
+    :return: Given value encoded into MySQL literal.
+    :rtype: str
+    """
+    return pymysql.converters.escape_item(value, "utf-8")

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 pytest
 pytest-cov
--e .
+-e .[MySQL]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,9 @@ install_requires =
     mock>=2.0.0 ; python_version < '3'
     six>=1.11.0
 
+[options.extras_require]
+MySQL = PyMySQL
+
 [options.packages.find]
 exclude =
     database_sanitizer.tests


### PR DESCRIPTION
Extend sanitizer database support with support for MySQL databases. The MySQL sanitizer uses `mysqldump` utility to obtain copy of the database in SQL format, then looks for `INSERT INTO` statements (in MySQL's own "extended format") from the output generated by `mysqldump`, parsing values from them, sanitizing the parsed values and finally generating new `INSERT INTO` statement from the sanitized values.