### PR TITLE
Add support for PostGIS

### DIFF
--- a/database_sanitizer/dump/__init__.py
+++ b/database_sanitizer/dump/__init__.py
@@ -11,13 +11,13 @@ SUPPORTED_DATABASE_MODULES = {
     "mysql": "database_sanitizer.dump.mysql",
     "postgres": "database_sanitizer.dump.postgres",
     "postgresql": "database_sanitizer.dump.postgres",
+    "postgis": "database_sanitizer.dump.postgres",
 }
 
 
 # Register supported database schemes.
-urlparse.uses_netloc.append("mysql")
-urlparse.uses_netloc.append("postgres")
-urlparse.uses_netloc.append("postgresql")
+for scheme in SUPPORTED_DATABASE_MODULES.keys():
+    urlparse.uses_netloc.append(scheme)
 
 
 def run(url, output, config):

--- a/database_sanitizer/dump/postgres.py
+++ b/database_sanitizer/dump/postgres.py
@@ -29,7 +29,7 @@ def sanitize(url, config):
                    of the values stored in the database.
     :type config: database_sanitizer.config.Configuration|None
     """
-    if url.scheme not in ("postgres", "postgresql"):
+    if url.scheme not in ("postgres", "postgresql", "postgis"):
         raise ValueError("Unsupported database type: '%s'" % (url.scheme,))
 
     process = subprocess.Popen(
@@ -42,7 +42,7 @@ def sanitize(url, config):
             # Luckily `pg_dump` supports DB URLs, so we can just pass it the
             # URL as argument to the command.
             "--dbname",
-            url.geturl(),
+            url.geturl().replace('postgis://', 'postgresql://'),
         ),
         stdout=subprocess.PIPE,
     )


### PR DESCRIPTION
PostGIS can be dumped with the same pg_dump tool as normal PostgreSQL
databases, so to support it, we only need to make sure that "postgis"
scheme is handled correctly in the database URLs and convert it to
"postgresql" when passing such URL to pg_dump.