### PR TITLE
Add path of the config file to Python path

### DIFF
--- a/database_sanitizer/__main__.py
+++ b/database_sanitizer/__main__.py
@@ -19,7 +19,6 @@ def main(args=None):
     parser.add_argument(
         "--config",
         "-c",
-        nargs=1,
         type=str,
         dest="config",
         help="Path to the sanitizer configuration file.",
@@ -27,7 +26,6 @@ def main(args=None):
     parser.add_argument(
         "--output",
         "-o",
-        nargs=1,
         type=str,
         dest="output",
         help=(
@@ -45,9 +43,9 @@ def main(args=None):
     config = None
 
     if args.config:
-        config = Configuration.from_file(args.config[0])
+        config = Configuration.from_file(args.config)
     if args.output:
-        output = open(args.output[0], "w")
+        output = open(args.output, "w")
 
     try:
         run(

--- a/database_sanitizer/__main__.py
+++ b/database_sanitizer/__main__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import argparse
+import os
 import sys
 
 from .config import Configuration
@@ -43,6 +44,8 @@ def main(args=None):
     config = None
 
     if args.config:
+        conf_dir = os.path.realpath(os.path.dirname(args.config))
+        sys.path.insert(0, conf_dir)
         config = Configuration.from_file(args.config)
     if args.output:
         output = open(args.output, "w")


### PR DESCRIPTION
There could be global sanitizers present at the path of the configuration
file.  Make sure that those are importable without setting the PYTHONPATH
environment variable.