### PR TITLE
Improve Py2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ strategy:
     secret_key: string.empty
 ```
 
+**Note:** In Py2 environments you need to use `!!python/unicode` yaml tag to
+have the sanitizer config values properly converted into `unicode` objects.
+So e.g.:
+
+```YAML
+strategy:
+  user:
+    first_name: !!python/unicode name.first_name
+```
+
 In the example configuration above, there are first listed two "addon
 packages", which are names of Python packages where the sanitizer will
 be looking for sanitizer functions. They are completely optional and can

--- a/database_sanitizer/dump/mysql.py
+++ b/database_sanitizer/dump/mysql.py
@@ -78,7 +78,8 @@ def sanitize_from_stream(stream, config):
                    of the values stored in the database.
     :type config: database_sanitizer.config.Configuration|None
     """
-    for line in io.TextIOWrapper(stream, encoding="utf-8"):
+    for line in iter(stream.readline, b""):
+        line = line.decode("utf-8")
         # Eat the trailing new line.
         line = line.rstrip("\n")
 

--- a/database_sanitizer/dump/postgres.py
+++ b/database_sanitizer/dump/postgres.py
@@ -50,7 +50,8 @@ def sanitize(url, config):
     current_table = None
     current_table_columns = None
 
-    for line in io.TextIOWrapper(process.stdout, encoding="utf-8"):
+    for line in iter(process.stdout.readline, b""):
+        line = line.decode("utf-8")
         # Eat the trailing new line.
         line = line.rstrip("\n")
 


### PR DESCRIPTION
Creating a sanitized dump on Py2.7 environment errored for two reasons and this PR should address those issues.

Suggestions on improving the solution are very much welcome since having Py2 and 3 compatible code seems to be often tricky business especially when working with `subprocess` module.