### PR TITLE
Add option to leave out table contents completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ strategy:
     first_name: name.first_name
     last_name: name.last_name
     secret_key: string.empty
+  access_log: skip_rows
 ```
 
 In the example configuration above, there are first listed two "addon
@@ -108,3 +109,9 @@ sanitation function consists from two parts separated from each other by
 a dot: Python module name and name of the actual function, which will
 be prefixed with `sanitize_`, so `name.first_name` would be a function
 called `sanitize_first_name` in a file called `name.py`.
+
+Table content can be left out completely from the sanitized dump by
+setting table strategy to `skip_rows` (check `access_log` table in the
+example config). This will leave out all `INSERT INTO` (MySQL) or `COPY`
+(PostgreSQL) statements from the sanitized dump file. `CREATE TABLE`
+statements will not be removed.

--- a/database_sanitizer/config.py
+++ b/database_sanitizer/config.py
@@ -9,6 +9,7 @@ import yaml
 
 __all__ = ("Configuration", "ConfigurationError")
 
+SKIP_ROWS_CONFIG_VALUE = "skip_rows"
 MYSQLDUMP_DEFAULT_PARAMETERS = ["--single-transaction"]
 PG_DUMP_DEFAULT_PARAMETERS = []
 
@@ -26,6 +27,7 @@ class Configuration(object):
     """
     def __init__(self):
         self.sanitizers = {}
+        self.skip_rows_for_tables = []
         self.addon_packages = []
         self.mysqldump_params = []
         self.pg_dump_params = []
@@ -166,13 +168,18 @@ class Configuration(object):
         if not isinstance(section_strategy, dict):
             if section_strategy is None:
                 return
-            raise ConfigurationError(
-                "'strategy' is %s instead of dict" % (
-                    type(section_strategy),
-                ),
-            )
+            if section_strategy != SKIP_ROWS_CONFIG_VALUE:
+                raise ConfigurationError(
+                    "'strategy' is %s instead of dict" % (
+                        type(section_strategy),
+                    ),
+                )
 
         for table_name, column_data in six.iteritems(section_strategy):
+            if column_data == SKIP_ROWS_CONFIG_VALUE:
+                self.skip_rows_for_tables.append(table_name)
+                continue
+
             if not isinstance(column_data, dict):
                 if column_data is None:
                     continue

--- a/database_sanitizer/dump/mysql.py
+++ b/database_sanitizer/dump/mysql.py
@@ -103,6 +103,11 @@ def sanitize_from_stream(stream, config):
         table_name = insert_into_match.group("table")
         column_names = parse_column_names(insert_into_match.group("columns"))
 
+        # Skip `INSERT INTO` statement if table rows are configured
+        # to be skipped.
+        if table_name in config.skip_rows_for_tables:
+            continue
+
         # Collect sanitizers possibly used for this table and place them into
         # a dictionary from which we can look them up by index later.
         sanitizers = {}

--- a/database_sanitizer/tests/test_config.py
+++ b/database_sanitizer/tests/test_config.py
@@ -137,6 +137,29 @@ def test_load_sanitizers():
     assert "table2.column1" in config.sanitizers
 
 
+def test_table_skip_rows_configuration():
+    config = Configuration()
+
+    with pytest.raises(ConfigurationError):
+        config.load_sanitizers({"strategy": "test"})
+
+    def mock_find_sanitizer(*args):
+        return lambda value: value
+
+    with mock.patch("database_sanitizer.config.Configuration.find_sanitizer",
+                    side_effect=mock_find_sanitizer):
+
+        config.load_sanitizers({"strategy": {
+            "table1": "skip_rows",
+            "table2": {
+                "column1": "test",
+            }
+        }})
+
+    assert "table2.column1" in config.sanitizers
+    assert "table1" in config.skip_rows_for_tables
+
+
 def test_find_sanitizer():
     config = Configuration()
 


### PR DESCRIPTION
Add option to mark table rows to be omitted from sanitized database dump. This will remove all `INSERT INTO` (MySQL) and `COPY` (PostgreSQL) statements to those tables that are configured to have its rows skipped.

This is useful for tables that contain non-critical data such as logs.