### PR TITLE
Use yaml.safe_load to read the configuration

### DIFF
--- a/database_sanitizer/config.py
+++ b/database_sanitizer/config.py
@@ -46,7 +46,7 @@ class Configuration(object):
         instance = cls()
 
         with open(filename, "rb") as file_stream:
-            config_data = yaml.load(file_stream)
+            config_data = yaml.safe_load(file_stream)
 
         instance.load(config_data)
 

--- a/database_sanitizer/tests/test_config.py
+++ b/database_sanitizer/tests/test_config.py
@@ -10,7 +10,7 @@ from ..config import Configuration, ConfigurationError
 
 
 @mock.patch.object(config, 'open')
-@mock.patch('yaml.load')
+@mock.patch('yaml.safe_load')
 def test_from_file(mocked_yaml_load, mocked_open):
     mocked_yaml_load.return_value = {}
 


### PR DESCRIPTION
Use "yaml.safe_load" rather than the unsafe "yaml.load" to load the
configuration file.

Using bare "yaml.load" allows arbitary commands being executed from the
configuration file, which we probably don't want to allow.  See the link
below for details.

This fixes the following deprecation warning:

    YAMLLoadWarning: calling yaml.load() without Loader=... is
    deprecated, as the default Loader is unsafe. Please read
    https://msg.pyyaml.org/load for full details.