### PR TITLE
non-utf8 charset support for mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The configuration file uses following kind of syntax:
 
 ```YAML
 config:
+  charset: iso-8859-1 # defaults to utf-8 if missing, only affects mysqldump
   addons:
     - some.other.package
     - yet.another.package

--- a/database_sanitizer/config.py
+++ b/database_sanitizer/config.py
@@ -12,6 +12,7 @@ __all__ = ("Configuration", "ConfigurationError")
 SKIP_ROWS_CONFIG_VALUE = "skip_rows"
 MYSQLDUMP_DEFAULT_PARAMETERS = ["--single-transaction"]
 PG_DUMP_DEFAULT_PARAMETERS = []
+CHARSET_DEFAULT = "utf-8"
 
 
 class ConfigurationError(ValueError):
@@ -31,6 +32,7 @@ class Configuration(object):
         self.addon_packages = []
         self.mysqldump_params = []
         self.pg_dump_params = []
+        self.charset = ""
 
     @classmethod
     def from_file(cls, filename):
@@ -72,6 +74,16 @@ class Configuration(object):
         self.load_addon_packages(config_data)
         self.load_sanitizers(config_data)
         self.load_dump_extra_parameters(config_data)
+
+        charset = config_data.get("config",{}).get("charset", CHARSET_DEFAULT)
+        if not isinstance(charset, str):
+            raise ConfigurationError(
+                "'config' is %s instead of str" % (
+                    type(charset),
+                ),
+            )
+
+        self.charset = charset
 
     def load_dump_extra_parameters(self, config_data):
         """

--- a/database_sanitizer/dump/mysql.py
+++ b/database_sanitizer/dump/mysql.py
@@ -84,7 +84,7 @@ def sanitize_from_stream(stream, config):
                    of the values stored in the database.
     :type config: database_sanitizer.config.Configuration|None
     """
-    for line in io.TextIOWrapper(stream, encoding="utf-8"):
+    for line in io.TextIOWrapper(stream, encoding=config.charset):
         # Eat the trailing new line.
         line = line.rstrip("\n")
 


### PR DESCRIPTION
This change 

  - Adds new config option for `charset`, with default `utf-8`
  - Support charset option in `dump/mysql.py` dump reader class
  - Updates README accordingly